### PR TITLE
load default config with require directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,8 @@ class Loader {
   /**
    * constructor
    */
-  constructor(appPath, thinkPath) {
+  constructor(appPath) {
     this.appPath = appPath;
-    this.thinkPath = thinkPath;
     this.modules = [];
     const dir = path.join(appPath, 'common/config');
     if (helper.isDirectory(dir)) {
@@ -34,7 +33,7 @@ class Loader {
    * load config
    */
   loadConfig(env) {
-    return (new Config()).load(this.appPath, this.thinkPath, env, this.modules);
+    return (new Config()).load(this.appPath, env, this.modules);
   }
   /**
    * load bootstrap
@@ -71,7 +70,7 @@ class Loader {
    * load middleware
    */
   loadMiddleware(app) {
-    return (new Middleware()).load(this.appPath, this.thinkPath, this.modules, app);
+    return (new Middleware()).load(this.appPath, this.modules, app);
   }
   /**
    * load router
@@ -83,7 +82,7 @@ class Loader {
    * load extend
    */
   loadExtend() {
-    return extend.load(this.appPath, this.thinkPath, this.modules);
+    return extend.load(this.appPath, this.modules);
   }
   /**
    * load crontab

--- a/loader/extend.js
+++ b/loader/extend.js
@@ -6,6 +6,12 @@ const interopRequire = util.interopRequire;
 const extendObj = util.extend;
 const debug = require('debug')(`think-loader-extend-${process.pid}`);
 
+const SYS_EXTENDS = {
+  context: require('thinkjs/lib/extend/context'),
+  controller: require('thinkjs/lib/extend/controller'),
+  logic: require('thinkjs/lib/extend/logic')
+};
+
 const ExtendLoader = {
 
   allowExtends: ['think', 'application', 'context', 'request', 'response', 'controller', 'logic', 'service'],
@@ -20,15 +26,16 @@ const ExtendLoader = {
    *  modelExtend,
    * ]
    */
-  load(appPath, thinkPath, modules) {
+  load(appPath, modules) {
     const allowExtends = ExtendLoader.allowExtends;
-    const thinkFilePath = path.join(thinkPath, 'lib/config/extend.js');
-    let extend = interopRequire(thinkFilePath);
+
+    let extend = {};
     const filepath = path.join(appPath, modules.length ? 'common/config/extend.js' : 'config/extend.js');
     if (helper.isFile(filepath)) {
       debug(`load file: ${filepath}`);
       extend = extend.concat(interopRequire(filepath));
     }
+
     const ret = {};
     function assign(type, ext) {
       if (!ret[type]) {
@@ -37,14 +44,10 @@ const ExtendLoader = {
       ret[type] = extendObj(ret[type], ext);
     }
     // system extend
-    allowExtends.forEach(type => {
-      const filepath = path.join(thinkPath, `lib/extend/${type}.js`);
-      if (!helper.isFile(filepath)) {
-        return;
-      }
-      debug(`load file: ${filepath}`);
-      assign(type, interopRequire(filepath));
-    });
+    allowExtends
+      .filter(type => SYS_EXTENDS[type])
+      .forEach(type => assign(type, SYS_EXTENDS[type]));
+
     // config extend
     extend.forEach(item => {
       if (helper.isFunction(item)) {

--- a/loader/extend.js
+++ b/loader/extend.js
@@ -29,7 +29,7 @@ const ExtendLoader = {
   load(appPath, modules) {
     const allowExtends = ExtendLoader.allowExtends;
 
-    let extend = {};
+    let extend = [];
     const filepath = path.join(appPath, modules.length ? 'common/config/extend.js' : 'config/extend.js');
     if (helper.isFile(filepath)) {
       debug(`load file: ${filepath}`);

--- a/loader/middleware.js
+++ b/loader/middleware.js
@@ -10,7 +10,7 @@ const SYS_MIDDLEWARES = {
   logic: require('thinkjs/lib/middleware/logic'),
   meta: require('thinkjs/lib/middleware/meta'),
   payload: require('thinkjs/lib/middleware/payload'),
-  resource: require('thinkjs/lib/middleware/router'),
+  resource: require('thinkjs/lib/middleware/resource'),
   router: require('thinkjs/lib/middleware/router'),
   trace: require('thinkjs/lib/middleware/trace')
 };

--- a/loader/middleware.js
+++ b/loader/middleware.js
@@ -5,6 +5,15 @@ const assert = require('assert');
 const pathToRegexp = require('path-to-regexp');
 const debug = require('debug')(`think-loader-middleware-${process.pid}`);
 
+const SYS_MIDDLEWARES = {
+  controller: require('thinkjs/lib/middleware/controller'),
+  logic: require('thinkjs/lib/middleware/logic'),
+  meta: require('thinkjs/lib/middleware/meta'),
+  payload: require('thinkjs/lib/middleware/payload'),
+  resource: require('thinkjs/lib/middleware/router'),
+  router: require('thinkjs/lib/middleware/router'),
+  trace: require('thinkjs/lib/middleware/trace')
+};
 class Middleware {
   interopRequire(path) {
     return interopRequire(path);
@@ -39,10 +48,10 @@ class Middleware {
   parse(middlewares = [], middlewarePkg = {}, app) {
     return middlewares.map(item => {
       if (helper.isString(item)) {
-        return {handle: item};
+        return { handle: item };
       }
       if (helper.isFunction(item)) {
-        return {handle: () => item};
+        return { handle: () => item };
       }
       return item;
     }).filter(item => {
@@ -87,7 +96,7 @@ class Middleware {
       // has match or ignore
       return (ctx, next) => {
         if ((match && !this.checkMatch(match, ctx)) ||
-            (ignore && this.checkMatch(ignore, ctx))) {
+          (ignore && this.checkMatch(ignore, ctx))) {
           return next();
         }
         return item.handle(ctx, next);
@@ -119,15 +128,14 @@ class Middleware {
   /**
    * load sys and app middlewares
    */
-  loadFiles(appPath, isMultiModule, thinkPath) {
-    const sysMiddlewares = this.getFiles(path.join(thinkPath, 'lib/middleware'));
+  loadFiles(appPath, isMultiModule) {
     const appMiddlewarePath = path.join(appPath, isMultiModule ? 'common/middleware' : 'middleware');
     const appMiddlewares = this.getFiles(appMiddlewarePath);
-    const middlewares = Object.assign({}, sysMiddlewares, appMiddlewares);
+    const middlewares = Object.assign({}, SYS_MIDDLEWARES, appMiddlewares);
     return middlewares;
   }
 
-  load(appPath, thinkPath, modules, app) {
+  load(appPath, modules, app) {
     let filepath = '';
     if (modules.length) {
       filepath = path.join(appPath, 'common/config/middleware.js');
@@ -139,7 +147,7 @@ class Middleware {
     }
     debug(`load file: ${filepath}`);
     const middlewares = this.interopRequire(filepath);
-    return this.parse(middlewares, this.loadFiles(appPath, modules.length, thinkPath), app);
+    return this.parse(middlewares, this.loadFiles(appPath, modules.length), app);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
   ],
   "dependencies": {
     "debug": "^2.6.1",
+    "path-to-regexp": "^1.7.0",
     "think-helper": "^1.0.0",
-    "path-to-regexp": "^1.7.0"
+    "thinkjs": "^3.2.10"
   },
   "devDependencies": {
     "ava": "^0.18.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "babel-core": "^6.22.1",
     "babel-eslint": "^7.1.1",
     "coveralls": "~2.11.16",
-    "eslint": "^3.19.0",
+    "eslint": "^4.19.1",
     "eslint-config-think": "^1.0.0",
     "mock-require": "^2.0.1",
     "nyc": "^7.0.0"

--- a/test/config.js
+++ b/test/config.js
@@ -70,7 +70,7 @@ test('load config isMultiModule === true', t => {
     'env',
     'adapter',
     path.join('appPath/common/adapter'),
-  { type: 'load adapter' },
+    { type: 'load adapter' },
     'load adapter result',
     extendParams2,
     'env',
@@ -79,7 +79,7 @@ test('load config isMultiModule === true', t => {
     'env',
     'adapter',
     path.join('appPath/common/adapter'),
-  { type: 'load adapter' },
+    { type: 'load adapter' },
     'load adapter result' ]);
 
   const expect = {
@@ -104,9 +104,9 @@ test('load config isMultiModule === false', t => {
 
   const paths = [path.join('appPath', 'config')];
   t.deepEqual(depsCalledParams, [
-    paths, 'env', undefined,  // loadConfig has been called with {paths, 'env'}
-    [path.join('thinkPath', 'lib/config')], 'env', 'adapter',  // loadConfig thinkAdapterConfig
-    paths, 'env', 'adapter',  // loadConfig adapter
+    paths, 'env', undefined, // loadConfig has been called with {paths, 'env'}
+    [path.join('thinkPath', 'lib/config')], 'env', 'adapter', // loadConfig thinkAdapterConfig
+    paths, 'env', 'adapter', // loadConfig adapter
     path.join('appPath', 'adapter'), // loadAdapter                             // loadAdapter config has been called with {paths, 'env'}
     {type: 'load adapter'}, 'load adapter result' // formatAdapter has been called with 'adapter call result'
   ]);

--- a/test/config.js
+++ b/test/config.js
@@ -8,9 +8,9 @@ function mockDeps(instance) {
   instance.loadConfig = function(a, b, c) {
     depsCalledParams.push(a, b, c);
     if (c === 'adapter') {
-      return {type: 'load adapter'};
+      return { type: 'load adapter' };
     }
-    return {a: 'this will overwrite thinkconfig', b: 2, c: 3};
+    return { a: 'this will overwrite thinkconfig', b: 2, c: 3 };
   };
   instance.loadAdapter = function(c) {
     depsCalledParams.push(c);
@@ -19,20 +19,17 @@ function mockDeps(instance) {
 
   instance.formatAdapter = function(e, f) {
     depsCalledParams.push(e, f);
-    return {adapter: 'adapter'};
+    return { adapter: 'adapter' };
   };
 
   return depsCalledParams;
 }
 
-function mockThinkConfig(t) {
-  mock('../loader/util.js', {interopRequire(p) {
-    t.is(p, path.join('thinkPath', 'lib/config/config.js'));
-    return {
-      thinkConfig: 'value of thinkConfig',
-      a: 1 // will be overwrite
-    };
-  }});
+function mockThinkConfig() {
+  mock('thinkjs/lib/config/config', {
+    thinkConfig: 'value of thinkConfig',
+    a: 1 // will be overwrite
+  });
 }
 
 function getConfig() {
@@ -41,31 +38,22 @@ function getConfig() {
 }
 
 test('load config isMultiModule === true', t => {
-  mockThinkConfig(t);
-
+  mockThinkConfig();
   const instance = getConfig();
   const depsCalledParams = mockDeps(instance);
-  var result = instance.load('appPath', 'thinkPath', 'env', ['dir1', 'common']);
+  var result = instance.load('appPath', 'env', ['dir1', 'common']);
 
-  // const paths = [
-  //   path.join('appPath', 'common'),
-  //   path.join('appPath', 'dir1')
-  // ];
-
-  // const paths2 = [
-  //   path.join('appPath', 'common')
-  // ];
-
-  var extendParams1 = [ 'thinkPath/lib/config',
+  var extendParams1 = [
     'appPath/common/config',
-    'appPath/dir1/config' ].map(p => path.join(p));
+    'appPath/dir1/config'
+  ].map(p => path.join(p));
 
-  var extendParams2 = extendParams1.slice(0, 2);
+  var extendParams2 = extendParams1.slice(0, 1);
 
   t.deepEqual(depsCalledParams, [
     extendParams1,
     'env',
-    undefined,
+    'config',
     extendParams1,
     'env',
     'adapter',
@@ -74,13 +62,13 @@ test('load config isMultiModule === true', t => {
     'load adapter result',
     extendParams2,
     'env',
-    undefined,
+    'config',
     extendParams2,
     'env',
     'adapter',
     path.join('appPath/common/adapter'),
     { type: 'load adapter' },
-    'load adapter result' ]);
+    'load adapter result']);
 
   const expect = {
     thinkConfig: 'value of thinkConfig',
@@ -96,23 +84,21 @@ test('load config isMultiModule === true', t => {
 });
 
 test('load config isMultiModule === false', t => {
-  mockThinkConfig(t);
+  mockThinkConfig();
 
   const instance = getConfig();
   const depsCalledParams = mockDeps(instance);
-  const result = instance.load('appPath', 'thinkPath', 'env', []);
+  const result = instance.load('appPath', 'env', []);
 
   const paths = [path.join('appPath', 'config')];
   t.deepEqual(depsCalledParams, [
-    paths, 'env', undefined, // loadConfig has been called with {paths, 'env'}
-    [path.join('thinkPath', 'lib/config')], 'env', 'adapter', // loadConfig thinkAdapterConfig
+    paths, 'env', 'config', // loadConfig has been called with {paths, 'env'}
     paths, 'env', 'adapter', // loadConfig adapter
     path.join('appPath', 'adapter'), // loadAdapter                             // loadAdapter config has been called with {paths, 'env'}
-    {type: 'load adapter'}, 'load adapter result' // formatAdapter has been called with 'adapter call result'
+    { type: 'load adapter' }, 'load adapter result' // formatAdapter has been called with 'adapter call result'
   ]);
 
   t.deepEqual(result, {
-    type: 'load adapter',
     thinkConfig: 'value of thinkConfig',
     a: 'this will overwrite thinkconfig',
     b: 2,

--- a/test/extend.js
+++ b/test/extend.js
@@ -7,14 +7,8 @@ function mockHelper(multiModule, isFile) {
   var params = [];
   helper.isFile = function(p) {
     params.push(p);
-    if (p === path.join('thinkPath', 'lib/config/extend.js')) {
-      return isFile[0];
-    } else if (p === path.join('appPath', multiModule ? 'common/config/extend.js' : 'config/extend.js')) {
+    if (p === path.join('appPath', multiModule ? 'common/config/extend.js' : 'config/extend.js')) {
       return isFile[1];
-    } else if (p === path.join('thinkPath', 'lib/extend/think.js')) {
-      return isFile[2];
-    } else if (p === path.join('thinkPath', 'lib/extend/context.js')) {
-      return isFile[3];
     } else if (p === path.join('appPath', (multiModule ? 'common/extend/think.js' : 'extend/think.js'))) {
       return isFile[4];
     } else if (p === path.join('appPath', (multiModule ? 'common/extend/context.js' : 'extend/context.js'))) {
@@ -29,26 +23,29 @@ function mockHelper(multiModule, isFile) {
 function mockUtil(multiModule, addNotAllow) {
   const util = require('../loader/util');
   util.interopRequire = function(p) {
-    if (p === path.join('thinkPath', 'lib/config/extend.js')) {
-      var ret = [{
-        think: {a: 1}
-      }];
-      if (addNotAllow) {
-        ret.push({notallow: {some: 'value'}});
-      }
-      return ret;
-    } else if (p === path.join('appPath', multiModule ? 'common/config/extend.js' : 'config/extend.js')) {
+    // if (p === path.join('thinkPath', 'lib/config/extend.js')) {
+    //   var ret = [{
+    //     think: { a: 1 }
+    //   }];
+    //   if (addNotAllow) {
+    //     ret.push({ notallow: { some: 'value' } });
+    //   }
+    //   return ret;
+    // } else
+    if (p === path.join('appPath', multiModule ? 'common/config/extend.js' : 'config/extend.js')) {
       return [{
-        context: {a: !!multiModule}
-      }];
-    } else if (p === path.join('thinkPath', 'lib/extend/think.js')) {
-      return {
-        b: 2
-      };
-    } else if (p === path.join('thinkPath', 'lib/extend/context.js')) {
-      return {
-        b: 2
-      };
+        context: { a: !!multiModule }
+      }, addNotAllow ? ({
+        notallow: { some: 'value' }
+      }) : {}];
+      // } else if (p === path.join('thinkPath', 'lib/extend/think.js')) {
+      //   return {
+      //     b: 2
+      //   };
+      // } else if (p === path.join('thinkPath', 'lib/extend/context.js')) {
+      //   return {
+      //     b: 2
+      //   };
     } else if (p === path.join('appPath',
       (multiModule ? 'common/extend/think.js' : 'extend/think.js'))) {
       return {
@@ -63,6 +60,12 @@ function mockUtil(multiModule, addNotAllow) {
       throw new Error();
     }
   };
+}
+
+function mockThinkExtends(isMultiModule) {
+  mock('thinkjs/lib/extend/context', { b: 2 });
+  mock('thinkjs/lib/extend/controller', { b: 2 });
+  mock('thinkjs/lib/extend/logic', { b: 2 });
 }
 
 function getLoader(a) {
@@ -81,10 +84,11 @@ function mockAssert() {
 
 function createTest(modules, isFileArray, expectReturn) {
   return t => {
+    mockThinkExtends(modules.length);
     mockHelper(modules.length, isFileArray);
     mockUtil(modules.length);
     const load = getLoader(['think', 'context']);
-    const ret = load('appPath', 'thinkPath', modules);
+    const ret = load('appPath', modules);
     t.deepEqual(ret, expectReturn);
   };
 }
@@ -93,8 +97,8 @@ test('test1', createTest(
   ['admin', 'user'],
   [true, true, true, true, true, true],
   {
-    think: {a: 1, b: 2, c: true},
-    context: {a: true, b: 2, c: true}
+    think: { c: true },
+    context: { a: true, b: 2, c: true }
   }
 ));
 
@@ -102,8 +106,8 @@ test('test2', createTest(
   [],
   [true, true, true, true, true, true],
   {
-    think: {a: 1, b: 2, c: false},
-    context: {a: false, b: 2, c: false}
+    think: { c: false },
+    context: { a: false, b: 2, c: false }
   }
 ));
 
@@ -111,8 +115,8 @@ test('test3', createTest(
   [],
   [true, false, true, true, true, true],
   {
-    think: {a: 1, b: 2, c: false},
-    context: {b: 2, c: false}
+    think: { c: false },
+    context: { b: 2, c: false }
   }
 ));
 
@@ -120,8 +124,8 @@ test('test4', createTest(
   [],
   [true, true, false, true, true, true],
   {
-    think: {a: 1, c: false},
-    context: {a: false, b: 2, c: false}
+    think: { c: false },
+    context: { a: false, b: 2, c: false }
   }
 ));
 
@@ -129,8 +133,8 @@ test('test5', createTest(
   [],
   [true, true, true, false, true, true],
   {
-    think: {a: 1, b: 2, c: false},
-    context: {a: false, c: false}
+    think: { c: false },
+    context: { a: false, b: 2, c: false }
   }
 ));
 
@@ -138,8 +142,7 @@ test('test6', createTest(
   [],
   [true, true, true, true, false, true],
   {
-    think: {a: 1, b: 2},
-    context: {a: false, b: 2, c: false}
+    context: { a: false, b: 2, c: false }
   }
 ));
 
@@ -147,8 +150,8 @@ test('test7', createTest(
   [],
   [true, true, true, true, true, false],
   {
-    think: {a: 1, b: 2, c: false},
-    context: {a: false, b: 2}
+    think: { c: false },
+    context: { a: false, b: 2 }
   }
 ));
 
@@ -157,8 +160,7 @@ test('assert type must be one of allowExtends', t => {
   mockUtil(false, true);
   var params = mockAssert();
   const load = getLoader(['think', 'context']);
-  load('appPath', 'thinkPath', []);
-
+  load('appPath', []);
   t.deepEqual(params.slice(2, 4), [
     false,
     `extend type=notallow not allowed, allow types: ${['think', 'context'].join(', ')}`

--- a/test/index.js
+++ b/test/index.js
@@ -10,11 +10,10 @@ function createLoader(modules = 'modules') {
 
 test('loadConfig will pass the right params and return', t => {
   mock('../loader/config.js', class config {
-    load(a, b, c, d) {
+    load(a, b, c) {
       t.is(a, 'apppath');
-      t.is(b, 'thinkpath');
-      t.is(c, 'env');
-      t.is(d, 'modules');
+      t.is(b, 'env');
+      t.is(c, 'modules');
       return 'config';
     }
   });
@@ -63,11 +62,10 @@ test('loadCommon will pass the right params and return', testCommon('loadCommon'
 
 test('loadMiddleware will pass the right params and return', t => {
   mock('../loader/middleware.js', class middleware {
-    load(a, b, c, d) {
+    load(a, b, c) {
       t.is(a, 'apppath');
-      t.is(b, 'thinkpath');
-      t.is(c, 'modules');
-      t.is(d, 'app');
+      t.is(b, 'modules');
+      t.is(c, 'app');
       return 'middleware';
     }
   });
@@ -76,11 +74,12 @@ test('loadMiddleware will pass the right params and return', t => {
 });
 
 test('loadRouter will pass the right params and return', t => {
-  mock('../loader/router.js', {load: function(a, b) {
-    t.is(a, 'apppath');
-    t.is(b, 'modules');
-    return 'router';
-  }
+  mock('../loader/router.js', {
+    load: function(a, b) {
+      t.is(a, 'apppath');
+      t.is(b, 'modules');
+      return 'router';
+    }
   });
   var loader = createLoader();
   t.is(loader.loadRouter(), 'router');

--- a/test/index_constructor.js
+++ b/test/index_constructor.js
@@ -35,14 +35,13 @@ function mockFs(t, isCommonConfigDirectory) {
 }
 
 function createLoader() {
-  return new Loader('appPath', 'thinkPath');
+  return new Loader('appPath');
 }
 
 test('Loader constructor properly set paths', t => {
   mockFs(t, false);
   var loader = createLoader();
   t.is(loader.appPath, 'appPath');
-  t.is(loader.thinkPath, 'thinkPath');
 });
 
 function testIsMultiModule(isCommonConfigDirectory, modules) {

--- a/test/index_constructor.js
+++ b/test/index_constructor.js
@@ -5,7 +5,7 @@ test.beforeEach(t => {
   const fs = require('fs');
   fs.___readdirSync = fs.readdirSync;
   fs.___statSync = fs.statSync;
-    // This runs after each test and other test hooks, even if they failed
+  // This runs after each test and other test hooks, even if they failed
 });
 
 function mockFs(t, isCommonConfigDirectory) {

--- a/test/middleware/load_files.js
+++ b/test/middleware/load_files.js
@@ -5,7 +5,7 @@ function mockGetFiles(instance) {
   callGetMidFilesParams = [];
   instance.getFiles = function(a) {
     callGetMidFilesParams.push(a);
-    return {[callGetMidFilesParams.length]: 'value'};
+    return { [callGetMidFilesParams.length]: 'value' };
   };
   return callGetMidFilesParams;
 }
@@ -18,29 +18,39 @@ function getInstance() {
 test('loadFiles isMultiModule === true', t => {
   const middleware = getInstance();
   const params = mockGetFiles(middleware);
-  const result = middleware.loadFiles('appPath', true, 'thinkPath');
+  const result = middleware.loadFiles('appPath', true);
   t.deepEqual(params, [
-    path.join('thinkPath', 'lib/middleware'),
     path.join('appPath', 'common/middleware')
   ]);
 
   t.deepEqual(result, {
     1: 'value',
-    2: 'value'
+    controller: require('thinkjs/lib/middleware/controller'),
+    logic: require('thinkjs/lib/middleware/logic'),
+    meta: require('thinkjs/lib/middleware/meta'),
+    payload: require('thinkjs/lib/middleware/payload'),
+    resource: require('thinkjs/lib/middleware/router'),
+    router: require('thinkjs/lib/middleware/router'),
+    trace: require('thinkjs/lib/middleware/trace')
   });
 });
 
 test('loadFiles isMultiModule === false', t => {
   const middleware = getInstance();
   const params = mockGetFiles(middleware);
-  const result = middleware.loadFiles('appPath', false, 'thinkPath');
+  const result = middleware.loadFiles('appPath', false);
   t.deepEqual(params, [
-    path.join('thinkPath', 'lib/middleware'),
     path.join('appPath', 'middleware')
   ]);
 
   t.deepEqual(result, {
     1: 'value',
-    2: 'value'
+    controller: require('thinkjs/lib/middleware/controller'),
+    logic: require('thinkjs/lib/middleware/logic'),
+    meta: require('thinkjs/lib/middleware/meta'),
+    payload: require('thinkjs/lib/middleware/payload'),
+    resource: require('thinkjs/lib/middleware/router'),
+    router: require('thinkjs/lib/middleware/router'),
+    trace: require('thinkjs/lib/middleware/trace')
   });
 });

--- a/test/middleware/loader.js
+++ b/test/middleware/loader.js
@@ -55,11 +55,11 @@ function createTest1(isFile, modules, path) {
   };
 }
 test('return [] when no middleware.js, isMultiModule = true',
- createTest1(false, ['admin'], path.join('appPath', 'common/config/middleware.js'))
+  createTest1(false, ['admin'], path.join('appPath', 'common/config/middleware.js'))
 );
 
 test('return [] when no middleware.js, isMultiModule = false',
- createTest1(false, [], path.join('appPath', 'config/middleware.js'))
+  createTest1(false, [], path.join('appPath', 'config/middleware.js'))
 );
 
 test('load middleware isMultiModule === true', t => {

--- a/test/middleware/loader.js
+++ b/test/middleware/loader.js
@@ -17,14 +17,14 @@ function mockDeps(instance) {
 
   instance.interopRequire = function(p) {
     if (path.join('appPath', 'common/config/middleware.js') === p) {
-      return {value: 'MultiModuleMiddlewares'};
+      return { value: 'MultiModuleMiddlewares' };
     } else if (path.join('appPath', 'config/middleware.js') === p) {
-      return {value: 'Middlewares'};
+      return { value: 'Middlewares' };
     }
   };
 
-  instance.loadFiles = function(a, b, c) {
-    depsCalledParams.push(a, b, c);
+  instance.loadFiles = function(a, b) {
+    depsCalledParams.push(a, b);
     return 'loadFiles call result';
   };
 
@@ -47,7 +47,7 @@ function createTest1(isFile, modules, path) {
     const instance = createInstance();
     const params = mockDeps(instance);
 
-    const result = instance.load('appPath', 'thinkPath', modules, 'app');
+    const result = instance.load('appPath', modules, 'app');
 
     t.deepEqual(isFileParams, [path]);
     t.deepEqual(params, []);
@@ -67,11 +67,11 @@ test('load middleware isMultiModule === true', t => {
   const instance = createInstance();
   const params = mockDeps(instance);
 
-  const result = instance.load('appPath', 'thinkPath', ['admin'], 'app');
+  const result = instance.load('appPath', ['admin'], 'app');
 
   t.deepEqual(params, [
-    'appPath', 1, 'thinkPath',
-    {value: 'MultiModuleMiddlewares'}, 'loadFiles call result', 'app'
+    'appPath', 1,
+    { value: 'MultiModuleMiddlewares' }, 'loadFiles call result', 'app'
   ]);
 
   t.is(result, 'parse call result');
@@ -82,11 +82,11 @@ test('load middleware isMultiModule === false', t => {
   const instance = createInstance();
   const params = mockDeps(instance);
 
-  const result = instance.load('appPath', 'thinkPath', [], 'app');
+  const result = instance.load('appPath', [], 'app');
 
   t.deepEqual(params, [
-    'appPath', 0, 'thinkPath',
-    {value: 'Middlewares'}, 'loadFiles call result', 'app'
+    'appPath', 0,
+    { value: 'Middlewares' }, 'loadFiles call result', 'app'
   ]);
 
   t.is(result, 'parse call result');

--- a/test/middleware/parse.js
+++ b/test/middleware/parse.js
@@ -57,7 +57,7 @@ test('middleware will be filter when !!enable is false', t => {
   const result = instance.parse([
     {
       handle: 'handler1',
-      options: 'options not filter2'  // not filter
+      options: 'options not filter2' // not filter
     },
     {
       handle: 'handler2',
@@ -87,7 +87,7 @@ test('middleware will pass options', t => {
   instance.parse([
     {
       handle: 'handler1',
-      options: 'options not filter2'  // not filter
+      options: 'options not filter2' // not filter
     },
     {
       handle: 'handler2'

--- a/test/router/load.js
+++ b/test/router/load.js
@@ -66,7 +66,7 @@ function mockUtil(contents) {
 }
 
 function createTest(modules, isFiles, fileContents,
- formatRouterCallParams, expectResult, expectAssertParams = []) {
+  formatRouterCallParams, expectResult, expectAssertParams = []) {
   return t => {
     var assertParams = [];
     mock('assert', function(a, b) {

--- a/test/util.js
+++ b/test/util.js
@@ -86,7 +86,7 @@ test('extend 3', t => {
       this.aaa = value;
     }
   };
-  const target = {  /* eslint accessor-pairs: ["error", { "setWithoutGet": false }] */
+  const target = { /* eslint accessor-pairs: ["error", { "setWithoutGet": false }] */
     set a(value) {
       this.bbb = 22;
     }


### PR DESCRIPTION
[@zeit/ncc](https://github.com/zeit/ncc) use webpack bundle all dependencies to a single file. While it's conflict with dynamic import. 

Thinkjs path is defined at https://github.com/thinkjs/thinkjs/blob/master/lib/loader.js#L11 while it's abnormal in bundle file. It's possible to static require all default config directly because of thinkjs module has not change those config file long time.
