### PR TITLE
load files start without dot 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - '6'
+  - '8'
+  - '10'
+  - '12'
 sudo: false
 script:
     - "npm test"

--- a/loader/common.js
+++ b/loader/common.js
@@ -6,7 +6,7 @@ const debug = require('debug')(`think-loader-common-${process.pid}`);
 const CommonLoader = {
   loadFiles(dir) {
     const files = helper.getdirFiles(dir).filter(file => {
-      return /\.js$/.test(file);
+      return /^(?!\.).+\.js$/i.test(file);
     });
     const cache = {};
     files.forEach(file => {

--- a/loader/config.js
+++ b/loader/config.js
@@ -47,7 +47,7 @@ class Config {
     const files = helper.getdirFiles(adapterPath);
     const ret = {};
     files.forEach(file => {
-      if (!/\.js$/.test(file)) return; // only load js files
+      if (!/^(?!\.).+\.js$/i.test(file)) return; // only load js files
       const item = file.replace(/\.\w+$/, '').split(path.sep);
       if (item.length !== 2 || !item[0] || !item[1]) {
         return;

--- a/test/middleware/load_files.js
+++ b/test/middleware/load_files.js
@@ -29,7 +29,7 @@ test('loadFiles isMultiModule === true', t => {
     logic: require('thinkjs/lib/middleware/logic'),
     meta: require('thinkjs/lib/middleware/meta'),
     payload: require('thinkjs/lib/middleware/payload'),
-    resource: require('thinkjs/lib/middleware/router'),
+    resource: require('thinkjs/lib/middleware/resource'),
     router: require('thinkjs/lib/middleware/router'),
     trace: require('thinkjs/lib/middleware/trace')
   });
@@ -49,7 +49,7 @@ test('loadFiles isMultiModule === false', t => {
     logic: require('thinkjs/lib/middleware/logic'),
     meta: require('thinkjs/lib/middleware/meta'),
     payload: require('thinkjs/lib/middleware/payload'),
-    resource: require('thinkjs/lib/middleware/router'),
+    resource: require('thinkjs/lib/middleware/resource'),
     router: require('thinkjs/lib/middleware/router'),
     trace: require('thinkjs/lib/middleware/trace')
   });


### PR DESCRIPTION
A file name starts with dot always means the file is a hidden file, it shouldn't be scan to ThinkJS. I update the regex to fix it.