### PR TITLE
fix(util): validator module internal errors not print

### DIFF
--- a/loader/util.js
+++ b/loader/util.js
@@ -5,9 +5,14 @@ const helper = require('think-helper');
 exports.interopRequire = function(obj, safe) {
   if (helper.isString(obj)) {
     if (safe) {
+      const isExist = helper.isExist(obj);
+
       try {
-        obj = require(obj);
+        obj = isExist
+          ? require(obj)
+          : null;
       } catch (e) {
+        console.error(e);
         obj = null;
       }
     } else {


### PR DESCRIPTION
引入config/validator.js模块时报错不会被打印。
比如我在validator.js中引入了ajv，但是忘记安装ajv，终端不会显示任何错误提示，不利于错误排查。