### PR TITLE
Use an alias for require method in `interopRequire`

### DIFF
--- a/loader/util.js
+++ b/loader/util.js
@@ -1,4 +1,7 @@
 const helper = require('think-helper');
+
+const nodeRequire = require;
+
 /**
  * interop require
  */
@@ -6,12 +9,12 @@ exports.interopRequire = function(obj, safe) {
   if (helper.isString(obj)) {
     if (safe) {
       try {
-        obj = require(obj);
+        obj = nodeRequire(obj);
       } catch (e) {
         obj = null;
       }
     } else {
-      obj = require(obj);
+      obj = nodeRequire(obj);
     }
   }
   return obj && obj.__esModule ? obj.default : obj;


### PR DESCRIPTION
## 背景

尝试使用 ncc 打包应用 （只 bundle node_modules 里面的内容，src 目录保留）。但是 ncc 会重写 `require()` 调用。
（了解更多，直接微信私聊哈）

## 解决方案
尝试了在应用启动前覆盖 `require('think-loader/loader/util').interopRequire` 方法，打包测试可行（见截图）。
但是，灵机一动，要不咱直接在 `think-loader` 这个包的层面直接解决下？@lizheming  大佬帮合并了发个patch呗（如果合并了，作为回馈，回头我可以写一篇文章讲下我是怎么把 ncc 和 thinkjs 一块使用的）

![image](https://user-images.githubusercontent.com/8180186/208713650-d2c2179b-23f9-4e41-92ad-397f34f07ebb.png)



